### PR TITLE
Added ability to save as alpha3

### DIFF
--- a/third_party/reegion_select/ft.reegion_select.php
+++ b/third_party/reegion_select/ft.reegion_select.php
@@ -68,6 +68,7 @@ class Reegion_select_ft extends EE_Fieldtype {
 	{		
 		return array(
 			'countries' => $this->EE->lang->line('rs_countries'),
+			'countries_alpha3' => $this->EE->lang->line('rs_countries_alpha3'),
 			'states' => $this->EE->lang->line('rs_states'),
 			'provinces' => $this->EE->lang->line('rs_provinces'),
 			'provinces_states' => $this->EE->lang->line('rs_provinces_states'),
@@ -123,6 +124,13 @@ class Reegion_select_ft extends EE_Fieldtype {
 			case 'countries':
 				$regions = $countries;
 				break;
+			case 'countries_alpha3':
+				$regions = array();
+				foreach ($countries as $alpha2 => $country)
+				{
+					$regions[$countries_alpha3[$alpha2]] = $country;
+				}
+				break;
 			case 'states':
 				$regions = $states;
 				break;
@@ -170,6 +178,10 @@ class Reegion_select_ft extends EE_Fieldtype {
 			case 'countries':
 				return $countries[$data];
 				break;
+			case 'countries_alpha3':
+				$alpha2 = array_search($data, $countries_alpha3);
+				return $countries[$alpha2];
+				break;
 			case 'states':
 				return $states[$data];
 				break;
@@ -187,8 +199,15 @@ class Reegion_select_ft extends EE_Fieldtype {
 	}
 	
 	
-	function replace_alpha2($data, $params = array(), $tagdata = FALSE)
+	function replace_alpha2($data, $params = array(), $tagdata = FALSE, $lv_settings = array())
 	{
+		$settings = (!empty($lv_settings)) ? $lv_settings : $this->settings;
+		if($settings['region_type'] == 'countries_alpha3')
+		{
+			include PATH_THIRD.'reegion_select/libraries/regions.php';
+			$data = array_search($data, $countries_alpha3);
+		}
+		
 		// Alpha-2 is what we store in the database, so spit it out
 		return $data;
 	}
@@ -242,6 +261,11 @@ class Reegion_select_ft extends EE_Fieldtype {
 			case 'countries':
 				$r .= ' ' . $countries_alpha3[$data];
 				$r .= ' ' . $countries[$data];
+				break;
+			case 'countries_alpha3':
+				$alpha2 = array_search($data, $countries_alpha3);
+				$r .= ' ' . $alpha2;
+				$r .= ' ' . $countries[$alpha2];
 				break;
 			case 'states':
 				$r .= ' ' . $states[$data];

--- a/third_party/reegion_select/language/english/lang.reegion_select.php
+++ b/third_party/reegion_select/language/english/lang.reegion_select.php
@@ -3,6 +3,7 @@
 $lang = array(
 	'rs_region_type' => 'Region Type',
 	'rs_countries' => 'Countries',
+	'rs_countries_alpha3' => 'Countries (alpha3)',
 	'rs_states' => 'U.S. States',
 	'rs_provinces' => 'Canadian Provinces',
 	'rs_provinces_states' => 'Canadian Provinces and U.S. States',


### PR DESCRIPTION
Adds a new region type option which is Countries (alpha3). Basically it allows you to store the field data as alpha3, and the display_field dropdown menu uses alpha3 codes for the option values. Works better for CartThrob this way.

If you're not interested, no biggie, I can just maintain my own fork.
